### PR TITLE
Adding test for obfuscated scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Tests that are safe to execute, run reliably every time, and produce a standardi
 A VST should:
 - Answer a question, exiting with a standard code from the Prelude [lookup table](https://docs.prelude.org/docs/tests#results)
 - Have test and clean functions, the latter reversing any effects of the former
-- Compile into a standard binary
-- Be lightweight, both in footprint and resources used during execution 
+- Compile into a standard binary specific to an OS/architecture
 
 ## An example
 

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -4,7 +4,9 @@ import (
 	"io/fs"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"time"
 )
 
@@ -119,4 +121,25 @@ func Serve(address string, protocol string) {
 
 	conn.Write([]byte("hello"))
 	conn.Close()
+}
+
+func Run(command string) string {
+	if runtime.GOOS == "windows" {
+		cmd := exec.Command("cmd.exe", command)
+		stdout, err := cmd.Output()
+		if err != nil {
+			println(err.Error())
+			os.Exit(1)
+		}
+		return string(stdout)
+
+	} else {
+		cmd := exec.Command("bash", "-c", command)
+		stdout, err := cmd.Output()
+		if err != nil {
+			println(err.Error())
+			os.Exit(1)
+		}
+		return string(stdout)
+	}
 }

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -2,6 +2,7 @@ package Endpoint
 
 import (
 	"io/fs"
+	"net"
 	"os"
 	"path/filepath"
 	"time"
@@ -61,4 +62,35 @@ func Remove(path string) int {
 		return 103
 	}
 	return 100
+}
+
+func DialTCP(address string, message string) string {
+	tcpAddr, err := net.ResolveTCPAddr("tcp", address)
+	if err != nil {
+		println("Failed to resolve:", err.Error())
+		os.Exit(1)
+	}
+
+	conn, err := net.DialTCP("tcp", nil, tcpAddr)
+	if err != nil {
+		println("Connection failure:", err.Error())
+		os.Exit(1)
+	}
+
+	_, err = conn.Write([]byte(message))
+	if err != nil {
+		println("Write to server failed:", err.Error())
+		os.Exit(1)
+	}
+
+	reply := make([]byte, 1024)
+
+	_, err = conn.Read(reply)
+	if err != nil {
+		println("Write to server failed:", err.Error())
+		os.Exit(1)
+	}
+
+	conn.Close()
+	return string(reply)
 }

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -64,33 +64,45 @@ func Remove(path string) int {
 	return 100
 }
 
-func DialTCP(address string, message string) string {
+func DialTCP(address string, message string) int {
 	tcpAddr, err := net.ResolveTCPAddr("tcp", address)
 	if err != nil {
 		println("Failed to resolve:", err.Error())
-		os.Exit(1)
+		return 1
 	}
 
 	conn, err := net.DialTCP("tcp", nil, tcpAddr)
 	if err != nil {
 		println("Connection failure:", err.Error())
-		os.Exit(1)
+		return 1
 	}
 
 	_, err = conn.Write([]byte(message))
 	if err != nil {
 		println("Write to server failed:", err.Error())
-		os.Exit(1)
+		return 1
 	}
 
 	reply := make([]byte, 1024)
 
 	_, err = conn.Read(reply)
 	if err != nil {
-		println("Write to server failed:", err.Error())
-		os.Exit(1)
+		println("Read response failed:", err.Error())
+		return 1
 	}
 
 	conn.Close()
-	return string(reply)
+	println("Server reply: ", string(reply))
+	return 0
+}
+
+func Serve(address string, protocol string) {
+	listen, err1 := net.Listen(protocol, address)
+	if err1 != nil {
+		println("Listener (serve) failed:", err1.Error())
+		os.Exit(1)
+	}
+	defer listen.Close()
+
+	listen.Accept()
 }

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -105,5 +105,18 @@ func Serve(address string, protocol string) {
 	}
 	defer listen.Close()
 
-	listen.Accept()
+	conn, err2 := listen.Accept()
+	if err2 != nil {
+		println("Listener (read) failed:", err2.Error())
+		os.Exit(1)
+	}
+
+	buffer := make([]byte, 1024)
+	_, err3 := conn.Read(buffer)
+	if err3 != nil {
+		println("Connection (read) failed:", err3.Error())
+	}
+
+	conn.Write([]byte("hello"))
+	conn.Close()
 }

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -97,6 +97,7 @@ func DialTCP(address string, message string) int {
 }
 
 func Serve(address string, protocol string) {
+	println("Serving: ", address)
 	listen, err1 := net.Listen(protocol, address)
 	if err1 != nil {
 		println("Listener (serve) failed:", err1.Error())

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -125,7 +125,7 @@ func Serve(address string, protocol string) {
 
 func Run(command string) string {
 	if runtime.GOOS == "windows" {
-		cmd := exec.Command("cmd.exe", command)
+		cmd := exec.Command("cmd.exe", "/C", command)
 		stdout, err := cmd.Output()
 		if err != nil {
 			println(err.Error())

--- a/tests/53ff0bda-537e-4493-90cf-220145d9569a/53ff0bda-537e-4493-90cf-220145d9569a.go
+++ b/tests/53ff0bda-537e-4493-90cf-220145d9569a/53ff0bda-537e-4493-90cf-220145d9569a.go
@@ -6,18 +6,26 @@ CREATED: 2023-01-06 10:54:04.264000
 package main
 
 import (
-	"encoding/base64"
 	"fmt"
-	"os"
 	"github.com/preludeorg/test/endpoint"
+	"os"
+	"runtime"
 )
 
 func test() {
-	encoded := base64.StdEncoding.EncodeToString([]byte("whoami"))
-	task := fmt.Sprintf("base64 -D <<< %s | bash", encoded)
-	stdout := Endpoint.Run(task)
-	println(stdout)
-	os.Exit(100)
+	if runtime.GOOS == "windows" {
+		encoded := "dwBoAG8AYQBtAGkA"
+		task := fmt.Sprintf("powershell.exe -e %s", encoded)
+		stdout := Endpoint.Run(task)
+		println(stdout)
+		os.Exit(100)
+	} else {
+		encoded := "d2hvYW1p"
+		task := fmt.Sprintf("base64 -d <<< %s | bash", encoded)
+		stdout := Endpoint.Run(task)
+		println(stdout)
+		os.Exit(100)
+	}
 }
 
 func clean() {

--- a/tests/53ff0bda-537e-4493-90cf-220145d9569a/53ff0bda-537e-4493-90cf-220145d9569a.go
+++ b/tests/53ff0bda-537e-4493-90cf-220145d9569a/53ff0bda-537e-4493-90cf-220145d9569a.go
@@ -1,0 +1,44 @@
+//go:build !windows
+// +build !windows
+
+/*
+FILENAME: 53ff0bda-537e-4493-90cf-220145d9569a.go
+RULE: Block obfuscated scripts from running
+CREATED: 2023-01-06 10:54:04.264000
+*/
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func test() {
+	encoded := base64.StdEncoding.EncodeToString([]byte("whoami"))
+	task := fmt.Sprintf("base64 -D <<< %s | bash", encoded)
+
+	cmd := exec.Command("bash", "-c", task)
+	stdout, err := cmd.Output()
+
+	if err != nil {
+		println(err.Error())
+		os.Exit(1)
+	}
+	println(stdout)
+	os.Exit(100)
+}
+
+func clean() {
+	os.Exit(100)
+}
+
+func main() {
+	args := os.Args[1:]
+	if len(args) > 0 {
+		clean()
+	} else {
+		test()
+	}
+}

--- a/tests/53ff0bda-537e-4493-90cf-220145d9569a/53ff0bda-537e-4493-90cf-220145d9569a.go
+++ b/tests/53ff0bda-537e-4493-90cf-220145d9569a/53ff0bda-537e-4493-90cf-220145d9569a.go
@@ -1,6 +1,3 @@
-//go:build !windows
-// +build !windows
-
 /*
 FILENAME: 53ff0bda-537e-4493-90cf-220145d9569a.go
 RULE: Block obfuscated scripts from running
@@ -13,19 +10,13 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"github.com/preludeorg/test/endpoint"
 )
 
 func test() {
 	encoded := base64.StdEncoding.EncodeToString([]byte("whoami"))
 	task := fmt.Sprintf("base64 -D <<< %s | bash", encoded)
-
-	cmd := exec.Command("bash", "-c", task)
-	stdout, err := cmd.Output()
-
-	if err != nil {
-		println(err.Error())
-		os.Exit(1)
-	}
+	stdout := Endpoint.Run(task)
 	println(stdout)
 	os.Exit(100)
 }

--- a/tests/53ff0bda-537e-4493-90cf-220145d9569a/53ff0bda-537e-4493-90cf-220145d9569a.go
+++ b/tests/53ff0bda-537e-4493-90cf-220145d9569a/53ff0bda-537e-4493-90cf-220145d9569a.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
-	"os/exec"
 	"github.com/preludeorg/test/endpoint"
 )
 


### PR DESCRIPTION
Rule: Block execution of potentially obfuscated scripts

Currently coded for non-Windows.

Requires:
- Support Windows
- Full testing