### PR TITLE
test serving of port

### DIFF
--- a/tests/954f39fb-a418-4c10-ac65-a701b6e71183/954f39fb-a418-4c10-ac65-a701b6e71183.go
+++ b/tests/954f39fb-a418-4c10-ac65-a701b6e71183/954f39fb-a418-4c10-ac65-a701b6e71183.go
@@ -1,0 +1,36 @@
+/*
+NAME: 954f39fb-a418-4c10-ac65-a701b6e71183.go
+RULE: The device should not serve a network-connectable port
+CREATED: 2023-01-03
+*/
+package main
+
+import (
+	"github.com/preludeorg/test/endpoint"
+	"os"
+	"time"
+)
+
+func test() {
+	go Endpoint.Serve("localhost:8888", "tcp")
+	time.Sleep(1 * time.Second)
+
+	code := Endpoint.DialTCP("localhost:8888", "hello")
+	if code == 0 {
+		os.Exit(101)
+	}
+	os.Exit(100)
+}
+
+func clean() {
+	os.Exit(100)
+}
+
+func main() {
+	args := os.Args[1:]
+	if len(args) > 0 {
+		clean()
+	} else {
+		test()
+	}
+}


### PR DESCRIPTION
Rule: The device should not serve a network-connectable port 