### PR TITLE
Need /C to execute properly on windows

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -125,7 +125,7 @@ func Serve(address string, protocol string) {
 
 func Run(command string) string {
 	if runtime.GOOS == "windows" {
-		cmd := exec.Command("cmd.exe", command)
+		cmd := exec.Command("cmd.exe", "/C", command)
 		stdout, err := cmd.Output()
 		if err != nil {
 			println(err.Error())


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/67713732/212359530-fe480f25-e4e9-4fb0-8dc9-1a54d99e9aae.png)

In order for commands to properly work we need the /C similar to bash's -c 