### PR TITLE
Add file rename to Quarantined function

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -48,14 +48,16 @@ func Exists(path string) bool {
 	}
 }
 
-func Quarantined(path string, contents []byte) bool {
+func Quarantined(path string, contents []byte, quarantinePath string) bool {
 	Write(path, contents)
-	time.Sleep(2 * time.Second)
+	time.Sleep(1 * time.Second)
 	if Exists(path) {
-		return false
-	} else {
-		return true
+		err := os.Rename(path, quarantinePath)
+		if err != nil {
+			return true
+		}
 	}
+	return false
 }
 
 func Remove(path string) int {


### PR DESCRIPTION
Modified the` Quarantined `function in Endpoint to add a second step after the pause to attempt to rename the malicious file that is dropped. Also lowered the sleep from 2 seconds to 1 second.

<img width="692" alt="Screenshot 2023-01-22 at 11 00 11 PM" src="https://user-images.githubusercontent.com/54591490/213963742-01c25afc-b169-4fe7-b359-cd44bf53704f.png">
