### PR TITLE
Update endpoint to include file open step

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -69,12 +69,15 @@ func Exists(path string) bool {
 
 func Quarantined(path string, contents []byte) bool {
 	Write(path, contents)
-	time.Sleep(2 * time.Second)
+	time.Sleep(1 * time.Second)
 	if Exists(path) {
-		return false
-	} else {
-		return true
+		file, err := os.Open(path)
+		if err != nil {
+			return true
+		}
+		defer file.Close()
 	}
+	return false
 }
 
 func Remove(path string) int {


### PR DESCRIPTION
Tested this extra step against Defender since it corrupts the malicious file the file should fail to open if the the file exists. 


<img width="505" alt="Screenshot 2023-01-23 at 8 42 00 AM" src="https://user-images.githubusercontent.com/54591490/214054196-c1c212e3-02b5-4ad7-a807-bc1803620d4f.png">


<img width="680" alt="Screenshot 2023-01-23 at 8 39 45 AM" src="https://user-images.githubusercontent.com/54591490/214053701-308106b0-c30e-480a-a7f7-2fe4ec6b40c1.png">
