### PR TITLE
better logic obf logic

### DIFF
--- a/tests/53ff0bda-537e-4493-90cf-220145d9569a/53ff0bda-537e-4493-90cf-220145d9569a.go
+++ b/tests/53ff0bda-537e-4493-90cf-220145d9569a/53ff0bda-537e-4493-90cf-220145d9569a.go
@@ -24,9 +24,8 @@ func test() {
 	if strings.Contains(result, "Prelude") {
 		println(result)
 		Endpoint.Stop(101)
-	} else {
-		Endpoint.Stop(100)
-	}
+	} 
+	Endpoint.Stop(100)
 }
 
 func clean() {

--- a/tests/53ff0bda-537e-4493-90cf-220145d9569a/53ff0bda-537e-4493-90cf-220145d9569a.go
+++ b/tests/53ff0bda-537e-4493-90cf-220145d9569a/53ff0bda-537e-4493-90cf-220145d9569a.go
@@ -6,8 +6,10 @@ CREATED: 2023-01-06 10:54:04.264000
 package main
 
 import (
-	"github.com/preludeorg/test/endpoint"
 	"runtime"
+	"strings"
+
+	Endpoint "github.com/preludeorg/test/endpoint"
 )
 
 var supported = map[string][]string{
@@ -22,6 +24,8 @@ func test() {
 	if strings.Contains(result, "Prelude") {
 		println(result)
 		Endpoint.Stop(101)
+	} else {
+		Endpoint.Stop(100)
 	}
 }
 

--- a/tests/53ff0bda-537e-4493-90cf-220145d9569a/53ff0bda-537e-4493-90cf-220145d9569a.go
+++ b/tests/53ff0bda-537e-4493-90cf-220145d9569a/53ff0bda-537e-4493-90cf-220145d9569a.go
@@ -11,16 +11,18 @@ import (
 )
 
 var supported = map[string][]string{
-	"windows": {"powershell.exe", "-e", "dwBoAG8AYQBtAGkA"},
-	"darwin":  {"bash", "-c", "base64 -d <<< d2hvYW1p | bash"},
-	"linux":   {"bash", "-c", "base64 -d <<< d2hvYW1p | bash"},
+	"windows": {"powershell.exe", "-e", "ZQBjAGgAbwAgAC0AbgAgAFAAcgBlAGwAdQBkAGUA"},
+	"darwin":  {"bash", "-c", "base64 -d <<< ZWNobyAtbiBQcmVsdWRl | bash"},
+	"linux":   {"bash", "-c", "base64 -d <<< ZWNobyAtbiBQcmVsdWRl | bash"},
 }
 
 func test() {
 	command := supported[runtime.GOOS]
 	result := Endpoint.Shell(command)
-	println(result)
-	Endpoint.Stop(101)
+	if strings.Contains(result, "Prelude") {
+		println(result)
+		Endpoint.Stop(101)
+	}
 }
 
 func clean() {

--- a/tests/53ff0bda-537e-4493-90cf-220145d9569a/README.md
+++ b/tests/53ff0bda-537e-4493-90cf-220145d9569a/README.md
@@ -15,4 +15,4 @@ Any script that attempts to execute an encoded string should be blocked.
 
 > Safety: the encoded string is a non-intrusive command
 
-This test decodes the string "Prelude" in memory and executes it in a single action. If the string is found and the test is allowed to finish, it is considered a failure (of the defense), otherwise if it is blocked, it is considered a success.
+This test decodes the string "echo -n Prelude" in memory and executes it in a single action. If the string is found and the test is allowed to finish, it is considered a failure (of the defense), otherwise if it is blocked, it is considered a success.

--- a/tests/53ff0bda-537e-4493-90cf-220145d9569a/README.md
+++ b/tests/53ff0bda-537e-4493-90cf-220145d9569a/README.md
@@ -4,7 +4,9 @@ EDR products monitor every command run on an endpoint. As known bad commands are
 
 Example output: 
 ```
-ec2-user
+[+] Starting test
+Prelude
+[+] Completed with code: 101
 ```
 
 Any script that attempts to execute an encoded string should be blocked.
@@ -13,4 +15,4 @@ Any script that attempts to execute an encoded string should be blocked.
 
 > Safety: the encoded string is a non-intrusive command
 
-This test decodes the string "whoami" in memory and executes it in a single action. If the test is allowed to finish, it is considered a failure (of the defense), otherwise if it is blocked, it is considered a success.
+This test decodes the string "Prelude" in memory and executes it in a single action. If the string is found and the test is allowed to finish, it is considered a failure (of the defense), otherwise if it is blocked, it is considered a success.


### PR DESCRIPTION
this logic prints out the word Prelude and checks if it executed like that rather than whoami. example if whoami.exe doesn't exist or if whoami the linux/darwin bin doesn't exist (common in hardened env) 

<img width="301" alt="image" src="https://user-images.githubusercontent.com/67713732/215890892-b4fd6c40-0ff3-4c0f-a465-7c4b66b453a0.png">

does that mean we weren't able to execute as obf or?? but an echo simplifies the solution. 