### PR TITLE
Fix for error on Fedora

### DIFF
--- a/tests/021a1dbf-e080-495c-937e-7fa79d39bf30/021a1dbf-e080-495c-937e-7fa79d39bf30.go
+++ b/tests/021a1dbf-e080-495c-937e-7fa79d39bf30/021a1dbf-e080-495c-937e-7fa79d39bf30.go
@@ -14,7 +14,7 @@ import (
 var policy = map[string][]string{
 	"windows": {"powershell.exe", "-c", "net accounts"},
 	"darwin":  {"bash", "-c", "pwpolicy getaccountpolicies"},
-	"linux":   {"bash", "-c", "cat /etc/pam.d/common-password"},
+	"linux":   {"bash", "-c", "grep \"=\" /etc/security/pwquality.conf"},
 }
 
 var search = map[string][]string{


### PR DESCRIPTION
Previous command was throwing an error on Fedora because the file doesn't exist by default. This works for Ubuntu, Debian, and Fedora and shows default password quality requirements for the host.

<img width="536" alt="Screenshot 2023-02-02 at 10 15 18 PM" src="https://user-images.githubusercontent.com/54591490/216504152-e13ade83-69da-4e36-ada1-fca927532aa3.png">
