### PR TITLE
handle failed writes

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -51,11 +51,13 @@ func Read(path string) []byte {
 	return bit
 }
 
-func Write(path string, contents []byte) {
+func Write(path string, contents []byte) bool {
 	err := os.WriteFile(path, contents, 0644)
 	if err != nil {
 		println("[-] Failed to write " + path)
+		return false
 	}
+	return true
 }
 
 func Exists(path string) bool {

--- a/tests/61da9575-5c7e-471a-a3d7-27db8c7eea38/61da9575-5c7e-471a-a3d7-27db8c7eea38.go
+++ b/tests/61da9575-5c7e-471a-a3d7-27db8c7eea38/61da9575-5c7e-471a-a3d7-27db8c7eea38.go
@@ -7,10 +7,11 @@ package main
 
 import (
 	_ "embed"
-	Endpoint "github.com/preludeorg/test/endpoint"
 	"os"
 	"os/exec"
 	"runtime"
+
+	Endpoint "github.com/preludeorg/test/endpoint"
 )
 
 //go:embed test.py
@@ -54,7 +55,9 @@ func test() {
 	os.Setenv("GITHUB_USERNAME", "")
 	os.Setenv("GITHUB_PASSWORD", "")
 
-	Endpoint.Write(scriptPath, playwright)
+	if (Endpoint.Write(scriptPath, playwright)) != true {
+		Endpoint.Stop(write_fail_code)
+	}
 	var command string
 	if runtime.GOOS == "windows" {
 		command = "python"

--- a/tests/db201110-d875-4133-9709-2732a47f252f/db201110-d875-4133-9709-2732a47f252f.go
+++ b/tests/db201110-d875-4133-9709-2732a47f252f/db201110-d875-4133-9709-2732a47f252f.go
@@ -51,9 +51,15 @@ func test() {
 	println("[*] Targeting user: " + usr.Username)
 
 	println("[*] Generating sample files...")
-	Endpoint.Write(filepath.Join(usr.HomeDir, "one.txt"), make([]byte, 1000))
-	Endpoint.Write(filepath.Join(usr.HomeDir, "two.xlsx"), make([]byte, 7500000))
-	Endpoint.Write(filepath.Join(usr.HomeDir, "three.pdf"), make([]byte, 5500))
+	if Endpoint.Write(filepath.Join(usr.HomeDir, "one.txt"), make([]byte, 1000)) != true {
+		Endpoint.Stop(write_fail_code)
+	}
+	if Endpoint.Write(filepath.Join(usr.HomeDir, "two.xlsx"), make([]byte, 7500000)) != true {
+		Endpoint.Stop(write_fail_code)
+	}
+	if Endpoint.Write(filepath.Join(usr.HomeDir, "three.pdf"), make([]byte, 5500)) != true {
+		Endpoint.Stop(write_fail_code)
+	}
 
 	key, err := GenerateKey()
 	if err != nil {
@@ -72,7 +78,9 @@ func test() {
 			println(err)
 		}
 
-		Endpoint.Write(filepath.Join(usr.HomeDir, name), encryptBytes)
+		if Endpoint.Write(filepath.Join(usr.HomeDir, name), encryptBytes) != true {
+			Endpoint.Stop(write_fail_code)
+		}
 	}
 
 	Endpoint.Stop(101)


### PR DESCRIPTION
this is general and isn't required, this goes hand in hand with the quarantine. If you want to handle the failed write you can add 

```
if endpoint.write(blabla) != true{
    endpoint.stop(write_fail_code)
}

it also requires a custom write fail code to be implemented. 