### PR TITLE
Adding system utilities vst

### DIFF
--- a/tests/188af3a0-5a0d-4afe-8300-6b48915edba0/188af3a0-5a0d-4afe-8300-6b48915edba0.go
+++ b/tests/188af3a0-5a0d-4afe-8300-6b48915edba0/188af3a0-5a0d-4afe-8300-6b48915edba0.go
@@ -1,6 +1,6 @@
 /*
 ID: 188af3a0-5a0d-4afe-8300-6b48915edba0
-NAME: What hosts can I RDP or SSH into in my environment?
+NAME: What hosts can I remotely access in my environment?
 CREATED: 2023-02-15
 */
 package main

--- a/tests/188af3a0-5a0d-4afe-8300-6b48915edba0/188af3a0-5a0d-4afe-8300-6b48915edba0.go
+++ b/tests/188af3a0-5a0d-4afe-8300-6b48915edba0/188af3a0-5a0d-4afe-8300-6b48915edba0.go
@@ -1,0 +1,86 @@
+/*
+ID: 188af3a0-5a0d-4afe-8300-6b48915edba0
+NAME: What hosts can I RDP or SSH into in my environment?
+*/
+package main
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	Endpoint "github.com/preludeorg/test/endpoint"
+)
+
+func portScan() bool {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		panic(err)
+	}
+
+	var localIP net.IP
+	for _, addr := range addrs {
+		ipnet, ok := addr.(*net.IPNet)
+		if ok && !ipnet.IP.IsLoopback() && ipnet.IP.To4() != nil {
+			localIP = ipnet.IP
+			break
+		}
+	}
+
+	println("[+] Scanning network for open ports:")
+
+	var wg sync.WaitGroup
+
+	targetSubnet := localIP.Mask(net.CIDRMask(24, 32))
+	openPorts := make(map[string]bool)
+	var count int
+
+	for i := 1; i <= 254; i++ {
+		targetIP := net.IPv4(targetSubnet[0], targetSubnet[1], targetSubnet[2], byte(i))
+		ports := []int{22, 3389}
+
+		for _, port := range ports {
+			wg.Add(1)
+			go func(targetIP net.IP, port int) {
+				defer wg.Done()
+				target := fmt.Sprintf("%s:%d", targetIP.String(), port)
+				conn, err := net.DialTimeout("tcp", target, 1*time.Second)
+				if err == nil {
+					conn.Close()
+					openPorts[fmt.Sprintf("Port %d is open on %s", port, targetIP.String())] = true
+					count++
+				}
+			}(targetIP, port)
+		}
+	}
+
+	wg.Wait()
+
+	if count == 0 {
+		println("No hosts found with port 22 or port 3389 open")
+		return false
+	} else {
+		for result := range openPorts {
+			println(result)
+		}
+		return true
+	}
+}
+
+func test() {
+	openPorts := portScan()
+	if openPorts {
+		Endpoint.Stop(101)
+	} else {
+		Endpoint.Stop(100)
+	}
+}
+
+func clean() {
+	Endpoint.Stop(100)
+}
+
+func main() {
+	Endpoint.Start(test, clean)
+}

--- a/tests/188af3a0-5a0d-4afe-8300-6b48915edba0/188af3a0-5a0d-4afe-8300-6b48915edba0.go
+++ b/tests/188af3a0-5a0d-4afe-8300-6b48915edba0/188af3a0-5a0d-4afe-8300-6b48915edba0.go
@@ -1,6 +1,7 @@
 /*
 ID: 188af3a0-5a0d-4afe-8300-6b48915edba0
 NAME: What hosts can I RDP or SSH into in my environment?
+CREATED: 2023-02-15
 */
 package main
 

--- a/tests/188af3a0-5a0d-4afe-8300-6b48915edba0/README.md
+++ b/tests/188af3a0-5a0d-4afe-8300-6b48915edba0/README.md
@@ -1,0 +1,17 @@
+# Can you stop common remote system utilities?
+
+Lateral movement is a common goal of many adversaries most especially ransomware. The presence of open remote administration ports indicates a problem as it may allow unauthorized access to individual machines on the network in turn expanding the foothold and damage caused by an adversary inside the network during compromise. This test focuses on targetted port scanning of the two most common ports for ssh and RDP (22 and 3389).
+
+Example output:
+```
+[+] Starting test
+[+] Scanning network for open ports:
+No host found with port 22 or port 3389 open
+[+] Completed with code: 100
+```
+
+## How
+
+> Safety: the test only sends a TCP packet to the hosts to check if the specific port is open and no other data is sent
+
+This test finds the current internal IP address of the host and then conducts a port scan on the /24 subnet of that IP that scans for ports 22 (ssh) and 3389 (RDP) on the hosts within the range. If a host is found to have either of those ports open the test will exit with a 101 code. If no hosts are found with those ports open it will return a 100 code.


### PR DESCRIPTION
This test finds the current internal IP address of the host and then conducts a port scan on the /24 subnet of that IP that scans for ports 22 (ssh) and 3389 (RDP) on the hosts within the range. If a host is found to have either of those ports open the test will exit with a 101 code. If no hosts are found with those ports open it will return a 100 code.