### PR TITLE
Fix: Fixing extension on oRAT

### DIFF
--- a/tests/74077d3b-6a2f-49fa-903e-99cad6f34cf6/74077d3b-6a2f-49fa-903e-99cad6f34cf6.go
+++ b/tests/74077d3b-6a2f-49fa-903e-99cad6f34cf6/74077d3b-6a2f-49fa-903e-99cad6f34cf6.go
@@ -11,13 +11,13 @@ import (
 	Endpoint "github.com/preludeorg/test/endpoint"
 )
 
-//go:embed o.RAT
+//go:embed oRAT.bin
 var malicious []byte
 
 func test() {
 	println("[+] Extracting file for quarantine test")
 	println("[+] Pausing for 1 second to gauge defensive reaction")
-	if Endpoint.Quarantined("o.RAT", malicious) {
+	if Endpoint.Quarantined("oRAT.bin", malicious) {
 		println("[+] Malicious file was caught!")
 		Endpoint.Stop(105)
 	}


### PR DESCRIPTION
The .RAT was not playing nice on windows with the demo script. Switched to .bin.